### PR TITLE
fix(StudentSelector): 改善在浏览器视宽小于 768px 时，学生筛选界面的显示效果

### DIFF
--- a/apps/blue-archive-story-viewer/src/components/archive/StudentSelector.vue
+++ b/apps/blue-archive-story-viewer/src/components/archive/StudentSelector.vue
@@ -739,6 +739,7 @@ onUnmounted(() => {
   #student-selector-container {
     display: flex;
     flex-direction: column;
+    overflow-y: visible;
   }
 
   .filter-banner {
@@ -747,6 +748,7 @@ onUnmounted(() => {
     align-items: center;
     border-radius: 0;
     background-color: transparent;
+    overflow: visible;
     .clear-filter-icon {
       margin-right: 0.5rem;
       border-radius: 0.5rem;
@@ -791,12 +793,12 @@ onUnmounted(() => {
     grid-area: filter;
     padding-left: 0;
     width: 100%;
-    overflow-y: auto;
+    overflow-y: visible;
   }
 
   #student-list {
     grid-template-columns: repeat(auto-fill, 5rem);
-    overflow-y: auto;
+    overflow-y: visible;
   }
 }
 </style>

--- a/apps/blue-archive-story-viewer/src/components/archive/StudentSelector.vue
+++ b/apps/blue-archive-story-viewer/src/components/archive/StudentSelector.vue
@@ -254,6 +254,7 @@ const showFilter = ref(true);
 let currentWidth = window.innerWidth;
 let ticking = false;
 function updateShowFilter() {
+  // console.log("updateShowFilter", ticking, window.innerWidth, showFilter.value);
   if (ticking) return;
   ticking = true;
   window.requestAnimationFrame(() => {
@@ -790,10 +791,13 @@ onUnmounted(() => {
   .student-filter {
     grid-area: filter;
     padding-left: 0;
+    width: 100%;
+    overflow-y: auto;
   }
 
   #student-list {
     grid-template-columns: repeat(auto-fill, 5rem);
+    overflow-y: auto;
   }
 }
 </style>

--- a/apps/blue-archive-story-viewer/src/components/archive/StudentSelector.vue
+++ b/apps/blue-archive-story-viewer/src/components/archive/StudentSelector.vue
@@ -254,7 +254,6 @@ const showFilter = ref(true);
 let currentWidth = window.innerWidth;
 let ticking = false;
 function updateShowFilter() {
-  // console.log("updateShowFilter", ticking, window.innerWidth, showFilter.value);
   if (ticking) return;
   ticking = true;
   window.requestAnimationFrame(() => {

--- a/apps/blue-archive-story-viewer/src/style.scss
+++ b/apps/blue-archive-story-viewer/src/style.scss
@@ -317,7 +317,7 @@ a {
 }
 
 // consistent scrollbar style on all desktop browsers
-@media screen and (min-width: 768px) {
+@media screen {
   html[data-scrollbar="customize"] {
     //scrollbar-gutter: stable;
     //scrollbar-width: thin;
@@ -388,7 +388,6 @@ a {
 @media screen and (max-width: 768px) {
   body {
     padding: 0;
-    height: unset;
   }
 
   #app {


### PR DESCRIPTION
改善在浏览器视宽小于 768px 时，学生筛选界面的显示效果，改善效果如下图所示：

![](https://image-hosting-1312492736.cos.ap-beijing.myqcloud.com/imgs0/Snipaste_2023-10-16_14-29-08.jpg)

另外还有一个可以优化的点，对于 window 系统，在浏览器视宽小于 768px 时，由于垂直滚动条的存在（Widows 系统中的滚动条是会占据视口空间的），宽度设置为 100vw 的元素会有一部分被垂直滚动条遮挡，以及会出现水平滚动条（上图中也有体现这个问题）。