### PR TITLE
鼠标指针移动到MomoTalk选项上时背景自动变灰

### DIFF
--- a/apps/blue-archive-story-viewer/src/components/momotalk/MomoTalkComponent.vue
+++ b/apps/blue-archive-story-viewer/src/components/momotalk/MomoTalkComponent.vue
@@ -441,11 +441,17 @@ function handleContinueReadingButtonPressed() {
       background-color: var(--color-option-button);
       padding: 0.5rem;
       user-select: none;
+      transition: background-color ease-in-out .3s;
 
       &.selected {
         background-color: #5889c4;
         color: #fff;
       }
+    }
+
+    div:hover {
+      background-color: var(--color-option-button-hover);
+      transition: background-color ease-in-out .3s;
     }
   }
 }

--- a/apps/blue-archive-story-viewer/src/style.scss
+++ b/apps/blue-archive-story-viewer/src/style.scss
@@ -55,6 +55,7 @@ html {
   --color-momotalk-user-reply-background: #e5ebf1;
   --color-name-tag: #ffffffe0;
   --color-option-button: #fff;
+  --color-option-button-hover: #ddd;
   --color-player-avatar-border: #5c606e;
   --color-primary-button: #3f88f2;
   --color-student-filter-background: #d7d9e1b3;
@@ -130,6 +131,7 @@ html[data-theme="dark"] {
 
   --color-name-tag: #454545e0;
   --color-option-button: #333;
+  --color-option-button-hover: #555;
   --color-player-avatar-border: #eee;
   --color-primary-button: #4c7bb0;
   --color-student-filter-background: #2a2a2ab3;


### PR DESCRIPTION
#231 不会用色卡，把灰色一个个试过去之后觉得这两个颜色最顺眼（

只在控制台测试过，看样子不会破坏已有的界面（优先级比蓝色背景低）。