### PR TITLE
fix(player): 解决电视机雪花特效开局爆闪的问题

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -971,6 +971,9 @@ importers:
       '@pixi/filter-motion-blur':
         specifier: ~4.2.0
         version: 4.2.0(@pixi/constants@6.5.10)(@pixi/core@6.5.10(@pixi/constants@6.5.10)(@pixi/extensions@6.5.10)(@pixi/math@6.5.10)(@pixi/runner@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10))(@pixi/ticker@6.5.10(@pixi/extensions@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10)))(@pixi/utils@6.5.10(@pixi/constants@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10))))(@pixi/math@6.5.10)
+      '@pixi/filter-old-film':
+        specifier: '>=4.0.0 <5.0.0'
+        version: 4.2.0(@pixi/constants@6.5.10)(@pixi/core@6.5.10(@pixi/constants@6.5.10)(@pixi/extensions@6.5.10)(@pixi/math@6.5.10)(@pixi/runner@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10))(@pixi/ticker@6.5.10(@pixi/extensions@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10)))(@pixi/utils@6.5.10(@pixi/constants@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10))))
       '@pixi/particle-emitter':
         specifier: ~5.0.8
         version: 5.0.8(ijunv2opv7fqvwpofoqiqolwai)
@@ -3655,6 +3658,12 @@ packages:
     resolution: {integrity: sha512-CX+/06NVaw3HsjipZVb7aemkca0TC8I6qfKI4lx2ugxS/6G6zkY5zqd8+nVSXW4DpUXB6eT0emwfRv6N00NvuA==}
     peerDependencies:
       '@pixi/core': 6.5.10
+
+  '@pixi/filter-old-film@4.2.0':
+    resolution: {integrity: sha512-bHZgID3pUgAQXgg6ZJHardZYRcWchTIE5oc6I5KSqpXoOOaS2HRk89XMCgF2LG1Y+4UPbYkKOy1Twds+I3dNng==}
+    peerDependencies:
+      '@pixi/constants': ^6.0.0
+      '@pixi/core': ^6.0.0
 
   '@pixi/graphics@6.5.10':
     resolution: {integrity: sha512-KPHGJ910fi8bRQQ+VcTIgrK+bKIm8yAQaZKPqMtm14HzHPGcES6HkgeNY1sd7m8J4aS9btm5wOSyFu0p5IzTpA==}
@@ -15546,6 +15555,11 @@ snapshots:
 
   '@pixi/filter-noise@6.5.10(@pixi/core@6.5.10(@pixi/constants@6.5.10)(@pixi/extensions@6.5.10)(@pixi/math@6.5.10)(@pixi/runner@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10))(@pixi/ticker@6.5.10(@pixi/extensions@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10)))(@pixi/utils@6.5.10(@pixi/constants@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10))))':
     dependencies:
+      '@pixi/core': 6.5.10(@pixi/constants@6.5.10)(@pixi/extensions@6.5.10)(@pixi/math@6.5.10)(@pixi/runner@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10))(@pixi/ticker@6.5.10(@pixi/extensions@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10)))(@pixi/utils@6.5.10(@pixi/constants@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10)))
+
+  '@pixi/filter-old-film@4.2.0(@pixi/constants@6.5.10)(@pixi/core@6.5.10(@pixi/constants@6.5.10)(@pixi/extensions@6.5.10)(@pixi/math@6.5.10)(@pixi/runner@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10))(@pixi/ticker@6.5.10(@pixi/extensions@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10)))(@pixi/utils@6.5.10(@pixi/constants@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10))))':
+    dependencies:
+      '@pixi/constants': 6.5.10
       '@pixi/core': 6.5.10(@pixi/constants@6.5.10)(@pixi/extensions@6.5.10)(@pixi/math@6.5.10)(@pixi/runner@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10))(@pixi/ticker@6.5.10(@pixi/extensions@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10)))(@pixi/utils@6.5.10(@pixi/constants@6.5.10)(@pixi/settings@6.5.10(@pixi/constants@6.5.10)))
 
   '@pixi/graphics@6.5.10(vnjw7qx4yf6lp5siigycla6i5q)':

--- a/lib/ba-story-player/lib/layers/effectLayer/effectFunctions/BG_TvNoise_Sound.ts
+++ b/lib/ba-story-player/lib/layers/effectLayer/effectFunctions/BG_TvNoise_Sound.ts
@@ -2,8 +2,11 @@ import eventBus from "@/eventBus";
 import { usePlayerStore } from "@/stores";
 import { Container, Sprite, Texture, Graphics, filters } from "pixi.js";
 import { BGEffectHandlerFunction } from "@/types/effectLayer";
+import { OldFilmFilter } from "@pixi/filter-old-film";
 
-const BG_TvNoise_Sound: BGEffectHandlerFunction<'BG_TvNoise_Sound'> = async () => {
+const BG_TvNoise_Sound: BGEffectHandlerFunction<
+  "BG_TvNoise_Sound"
+> = async () => {
   // 原理是使用噪点滤镜产生电视机雪花的效果
   const { app } = usePlayerStore();
   const { width: appWidth, height: appHeight } = app.view;
@@ -11,51 +14,52 @@ const BG_TvNoise_Sound: BGEffectHandlerFunction<'BG_TvNoise_Sound'> = async () =
   const container = new Container();
   app.stage.addChild(container);
 
-  // 第一层，电视雪花效果
-  const screen = new Sprite(Texture.WHITE);
-  screen.tint = 0x000000; // 白色开局会爆闪一下
-  screen.width = appWidth;
-  screen.height = appHeight;
-  screen.filters = [
-    new filters.NoiseFilter(5),
-    new filters.BlurFilter(0.5),
-    new filters.FXAAFilter(),
-  ];
-  container.addChild(screen);
+  // 第一层，背景
+  const bg = new Sprite(Texture.WHITE);
+  bg.tint = 0x505050;
+  bg.width = appWidth;
+  bg.height = appHeight;
+  container.addChild(bg);
 
-  // 第二层，渐变效果
-  const mask = new Graphics();
-  mask.beginFill(0x000000);
-  mask.drawRect(0, 0, appWidth, appHeight / 4);
-  mask.drawRect(0, 0, appWidth / 4, appHeight);
-  mask.drawRect(0, appHeight * 3 / 4, appWidth, appHeight / 4);
-  mask.drawRect(appWidth * 3 / 4, 0, appWidth / 4, appHeight);
-  mask.endFill();
-  mask.filters = [new filters.AlphaFilter(0.3), new filters.BlurFilter(50)];
+  // 第二层，雪花 + 暗角遮罩
+  const mask = new Sprite(Texture.WHITE);
+  mask.width = appWidth;
+  mask.height = appHeight;
+  mask.alpha = 0.8;
+  mask.filters = [
+    new filters.NoiseFilter(8),
+    new filters.BlurFilter(0.5),
+    new OldFilmFilter({
+      noise: 0.47, // 不知道为什么不生效，可能 pixi 6 兼容问题？
+      sepia: 0,
+      noiseSize: 1.1,
+      scratch: 0, // 也是不生效，但是为防诈尸先禁用
+      vignetting: 0.2,
+      vignettingAlpha: 0.9,
+      vignettingBlur: 0.8,
+    }),
+  ];
+
   container.addChild(mask);
 
-  // 第三层，纵向移动的黑色条纹
+  // 第二层，纵向移动的黑色条纹
   const bar = new Graphics();
   bar.beginFill(0x000000);
   bar.drawRect(0, -appHeight / 2, appWidth, appHeight / 6);
-  bar.drawRect(0, -appHeight * 3 / 2, appWidth, appHeight / 12);
-  bar.drawRect(0, -appHeight * 5 / 2, appWidth, appHeight / 3);
+  bar.drawRect(0, (-appHeight * 3) / 2, appWidth, appHeight / 12);
+  bar.drawRect(0, (-appHeight * 5) / 2, appWidth, appHeight / 3);
   bar.endFill();
   bar.filters = [new filters.AlphaFilter(0.3), new filters.BlurFilter(5)];
   container.addChild(bar);
 
   let count = 0;
-  const tvNoiseSpeed = 5;
+  const tvNoiseSpeed = 3;
   const barMoveSpeed = 20;
   const animation = (delta: number) => {
     // 每隔一段时间添加噪点滤镜
     count += delta;
-    if (count > tvNoiseSpeed) {
-      screen.filters = [
-        new filters.NoiseFilter(5),
-        new filters.BlurFilter(0.5),
-        new filters.FXAAFilter(),
-      ];
+    if (count > tvNoiseSpeed && !!mask.filters) {
+      (mask.filters[0] as any).seed = Math.random(); // 仅更新噪点滤镜
       count %= tvNoiseSpeed;
     }
     // 黑色条纹纵向移动
@@ -63,7 +67,7 @@ const BG_TvNoise_Sound: BGEffectHandlerFunction<'BG_TvNoise_Sound'> = async () =
     if (bar.y > appHeight * 3.5) {
       bar.y = 0;
     }
-  }
+  };
   app.ticker.add(animation);
 
   eventBus.emit("playBgEffectSound", "BG_Flash_Sound");
@@ -71,7 +75,7 @@ const BG_TvNoise_Sound: BGEffectHandlerFunction<'BG_TvNoise_Sound'> = async () =
   return async () => {
     app.ticker.remove(animation);
     container.destroy();
-  }
-}
+  };
+};
 
 export default BG_TvNoise_Sound;

--- a/lib/ba-story-player/lib/layers/effectLayer/effectFunctions/BG_TvNoise_Sound.ts
+++ b/lib/ba-story-player/lib/layers/effectLayer/effectFunctions/BG_TvNoise_Sound.ts
@@ -16,6 +16,11 @@ const BG_TvNoise_Sound: BGEffectHandlerFunction<'BG_TvNoise_Sound'> = async () =
   screen.tint = 0x000000; // 白色开局会爆闪一下
   screen.width = appWidth;
   screen.height = appHeight;
+  screen.filters = [
+    new filters.NoiseFilter(5),
+    new filters.BlurFilter(0.5),
+    new filters.FXAAFilter(),
+  ];
   container.addChild(screen);
 
   // 第二层，渐变效果

--- a/lib/ba-story-player/package.json
+++ b/lib/ba-story-player/package.json
@@ -45,7 +45,8 @@
     "uuid": "~9.0.0",
     "@types/uuid": "~9.0.2",
     "element-plus": "^2.7.3",
-    "vite-plugin-vue-devtools": "^7.4.6"
+    "vite-plugin-vue-devtools": "^7.4.6",
+    "@pixi/filter-old-film": ">=4.0.0 <5.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",


### PR DESCRIPTION
#260

> 第二点是操作 screen 对象的时间太靠后了，加上初始化的 texture 是白色，因此特效开始的时候会爆闪一下。我暂时先 tint 成黑色了，不过如果要真正解决这个问题需要调整一下执行顺序

这个是我这边欠考虑了，相当于这个特效的第一帧几乎是纯白，会有爆闪的感觉，脑测应该是只要初始化的时候就是电视机雪花特效就不会有爆闪的问题（详见diff）。

@mark9804 头目看看还会不会有爆闪的问题😘。