### PR TITLE
Spine CDN load fix

### DIFF
--- a/lib/ba-story-player/lib/utils.ts
+++ b/lib/ba-story-player/lib/utils.ts
@@ -113,6 +113,7 @@ export function getResourcesUrl(type: ResourcesTypes, arg: string): string {
         : `${dataUrl}/spine/${filename}/${filename}.skel`;
       // ch*/np* sprites exist only on ba-all-data-spine42 (Spine 4.2).
       // named sprites — on ba-all-data (Spine 4.2); spine42 has stale 3.8 copies
+      // FIXME: CI intervention needed
       if (/^(ch|np)\d+/i.test(id ?? "")) {
         return getSpine42Url(skelPath);
       }

--- a/lib/ba-story-player/lib/utils.ts
+++ b/lib/ba-story-player/lib/utils.ts
@@ -107,12 +107,16 @@ export function getResourcesUrl(type: ResourcesTypes, arg: string): string {
       }
       // eslint-disable-next-line no-case-declarations
       const filename = `${id}_spr`; //hasumi_spr
-      if (superSampling) {
-        return getSpine42Url(
-          `${dataUrl}/spine/${filename}/${filename}${superSampling}/${filename}.skel`
-        );
+      // eslint-disable-next-line no-case-declarations
+      const skelPath = superSampling
+        ? `${dataUrl}/spine/${filename}/${filename}${superSampling}/${filename}.skel`
+        : `${dataUrl}/spine/${filename}/${filename}.skel`;
+      // ch* — only on ba-all-data-spine42 (Spine 4.2)
+      // named sprites — on ba-all-data (Spine 4.2); spine42 has stale 3.8 copies
+      if (/^ch\d+/i.test(id ?? "")) {
+        return getSpine42Url(skelPath);
       }
-      return getSpine42Url(`${dataUrl}/spine/${filename}/${filename}.skel`);
+      return rewritePath(skelPath);
     case "bg":
       // UIs/03_Scenario/01_Background/BG_WinterRoad.jpg
       if (superSampling && /01_Background/.test(arg)) {

--- a/lib/ba-story-player/lib/utils.ts
+++ b/lib/ba-story-player/lib/utils.ts
@@ -74,12 +74,12 @@ export function getResourcesUrl(type: ResourcesTypes, arg: string): string {
       return `${dataUrl}/effectTexture/${arg}`;
     case "l2dVoice":
       //arg "sound/CH0184_MemorialLobby_1_1"
-      // eslint-disable-next-line no-case-declarations
+       
       const voiceDirectory = arg.replace(
         /(?:.*\/)?([A-Z0-9]*)_MemorialLobby.*/i,
         "JP_$1"
       );
-      // eslint-disable-next-line no-case-declarations
+       
       const voiceFilename = arg.split("/").pop();
       return `${dataUrl}/Audio/VoiceJp/Character_voice/${voiceDirectory}/${voiceFilename}.${oggAudioType}`;
     case "l2dSpine":
@@ -97,23 +97,23 @@ export function getResourcesUrl(type: ResourcesTypes, arg: string): string {
       return `${dataUrl}/Audio/VoiceJp/${arg}.${oggAudioType}`;
     case "characterSpine":
       //arg UIs/03_Scenario/02_Character/CharacterSpine_hasumi
-      // eslint-disable-next-line no-case-declarations
+       
       const temp = String(arg).split("/");
-      // eslint-disable-next-line no-case-declarations
+       
       let id = temp.pop();
       id = id?.replace("CharacterSpine_", "");
       if (id?.endsWith("ND")) {
         id = id.slice(0, id.length - 2);
       }
-      // eslint-disable-next-line no-case-declarations
+       
       const filename = `${id}_spr`; //hasumi_spr
-      // eslint-disable-next-line no-case-declarations
+       
       const skelPath = superSampling
         ? `${dataUrl}/spine/${filename}/${filename}${superSampling}/${filename}.skel`
         : `${dataUrl}/spine/${filename}/${filename}.skel`;
-      // ch* — only on ba-all-data-spine42 (Spine 4.2)
+      // ch*/np* sprites exist only on ba-all-data-spine42 (Spine 4.2).
       // named sprites — on ba-all-data (Spine 4.2); spine42 has stale 3.8 copies
-      if (/^ch\d+/i.test(id ?? "")) {
+      if (/^(ch|np)\d+/i.test(id ?? "")) {
         return getSpine42Url(skelPath);
       }
       return rewritePath(skelPath);


### PR DESCRIPTION
The named sprites (e.g., `azusa.skel`) currently hosted on the CDN at the route `/ba-all-data-spine42` are version 3.8, instead of 4.2. This causes issues for player — for example, some parts of Chapter 3 fail to load.

This fix loads the named sprites from the route `/ba-all-data` instead.