### PR TITLE
patch cdn assets loading yet again

### DIFF
--- a/lib/ba-story-player/lib/index.ts
+++ b/lib/ba-story-player/lib/index.ts
@@ -31,6 +31,10 @@ import gsap from "gsap";
 import { PixiPlugin } from "gsap/PixiPlugin";
 // Howler 中间件
 import { HowlerLoader } from "@/middlewares/howlerPixiLoader";
+import {
+  needsNamedSpineResolve,
+  resolveNamedSpineSkelUrl,
+} from "@/namedSpineResolver";
 
 extensions.add(HowlerLoader);
 
@@ -1155,6 +1159,47 @@ async function loadAssetAlias(alias: string, src: string) {
 
 type IAddOptions = { src: string; alias: string };
 
+function isNotFoundError(err: unknown): boolean {
+  const message =
+    err instanceof Error
+      ? err.message
+      : typeof err === "string"
+        ? err
+        : String(err ?? "");
+  return message.includes("404");
+}
+
+/**
+ * Load spine skel+atlas.
+ * Named character sprites are probed on both CDNs for a non-404 Spine 4.2 copy.
+ * Assets are registered under the original (story) urls so Spine.from lookups keep working.
+ */
+async function loadSpineAsset(param: IAddOptions) {
+  const aliasSkel = param.src;
+  const aliasAtlas = aliasSkel.replace(/\.skel$/, ".atlas");
+  const skelAlias =
+    param.alias && param.alias !== aliasSkel
+      ? [param.alias, aliasSkel]
+      : aliasSkel;
+
+  let actualSkel = aliasSkel;
+  if (needsNamedSpineResolve(aliasSkel)) {
+    actualSkel = await resolveNamedSpineSkelUrl(aliasSkel);
+  }
+  const actualAtlas = actualSkel.replace(/\.skel$/, ".atlas");
+
+  await Assets.load({ src: actualAtlas, alias: aliasAtlas });
+  const loaded = await Assets.load({ src: actualSkel, alias: skelAlias });
+
+  // 创建 Spine 实例，从实例中读取出 L2D 音频资源进行预载
+  const spine = Spine.from({ skeleton: aliasSkel, atlas: aliasAtlas }); // 会报 warning，无伤大雅
+  const eventsList = spine.state.data.skeletonData.events;
+  if (eventsList && Array.isArray(eventsList)) {
+    resourcesLoader.loadL2dVoice(eventsList);
+  }
+  return loaded;
+}
+
 async function loadAsset(param: IAddOptions) {
   // param: {
   //   "src": "xxx/Emoticon_Balloon_N.png",
@@ -1176,19 +1221,7 @@ async function loadAsset(param: IAddOptions) {
       if (/\.(ogg|mp3|wav|mpeg)$/i.test(param.src)) {
         return Assets.backgroundLoad(param.src); // 后台加载声音资源，不要阻塞真正重要的视觉资源加载
       } else if (/\.skel$/.test(param.src)) {
-        // 是 spine 资源，显式猜测 atlas 路径并创建 bundle
-        const atlasUrl = param.src.replace(/\.skel$/, ".atlas");
-        // 添加 spine 和 atlas 资源
-        Assets.load({ src: atlasUrl, alias: atlasUrl });
-
-        await Assets.load(param); // 需要 await 完成后才能加载出东西
-
-        // 创建 Spine 实例，从实例中读取出 L2D 音频资源进行预载
-        const spine = Spine.from({ skeleton: param.src, atlas: atlasUrl }); // 会报 warning，无伤大雅
-        const eventsList = spine.state.data.skeletonData.events;
-        if (eventsList && Array.isArray(eventsList)) {
-          resourcesLoader.loadL2dVoice(eventsList);
-        }
+        return loadSpineAsset(param);
       }
       // 其他资源
       return Assets.load(param);
@@ -1205,7 +1238,7 @@ async function loadAsset(param: IAddOptions) {
       if (err.message?.includes("ERR_HTTP2_PROTOCOL_ERROR")) {
         console.error(`网络连接错误(${param.alias})：${err.message}`);
       }
-      if (err.message?.includes("404")) {
+      if (isNotFoundError(err)) {
         // 资源不存在，可以直接返回了
         console.error(`资源不存在: ${param.alias}`);
         return null;

--- a/lib/ba-story-player/lib/namedSpineResolver.ts
+++ b/lib/ba-story-player/lib/namedSpineResolver.ts
@@ -1,0 +1,146 @@
+/**
+ * Named character spines (e.g. hasumi_spr, justice_normal1_spr) may live on either
+ * ba-all-data or ba-all-data-spine42, and either copy may be Spine 3.8 or 4.2.
+ * Generic ch/np sprites always use spine42 and skip this resolver.
+ */
+
+const SPINE_VERSION_IN_BINARY = /(?:3\.8|4\.[0-2])(?:\.\d+)*/;
+const PEEK_BYTES = 255;
+const resolveCache = new Map<string, Promise<string>>();
+
+export function toSpine42CdnUrl(url: string): string {
+  if (url.includes("ba-all-data-spine42")) {
+    return url;
+  }
+  return url.replaceAll("ba-all-data", "ba-all-data-spine42");
+}
+
+export function toBaAllDataCdnUrl(url: string): string {
+  return url.replaceAll("ba-all-data-spine42", "ba-all-data");
+}
+
+/** Folder id without `_spr`, e.g. `hasumi` / `ch0066` / `justice_normal1`. */
+function spineFolderId(skelUrl: string): string | null {
+  const folder = skelUrl.match(/\/spine\/([^/]+)\//i)?.[1];
+  if (!folder || !/_spr$/i.test(folder)) {
+    return null;
+  }
+  return folder.replace(/_spr$/i, "");
+}
+
+export function isGenericCharacterSpineId(id: string): boolean {
+  return /^(ch|np)\d+$/i.test(id);
+}
+
+/** Named *_spr character skeletons need CDN+version probing. */
+export function needsNamedSpineResolve(skelUrl: string): boolean {
+  const id = spineFolderId(skelUrl);
+  return id !== null && !isGenericCharacterSpineId(id);
+}
+
+function parseSpineVersionFromBytes(buf: Uint8Array): string | null {
+  if (buf.length === 0) {
+    return null;
+  }
+  // JSON export
+  if (buf[0] === 0x7b /* { */) {
+    const text = new TextDecoder().decode(buf);
+    return text.match(/"spine"\s*:\s*"([^"]+)"/)?.[1] ?? null;
+  }
+  // Binary: hash layout differs 3.8 vs 4.x — scan for a version-looking ASCII run.
+  const text = new TextDecoder("latin1").decode(buf);
+  return text.match(SPINE_VERSION_IN_BINARY)?.[0] ?? null;
+}
+
+type PeekResult = {
+  url: string;
+  ok: boolean;
+  version: string | null;
+};
+
+async function peekSpineSkel(url: string): Promise<PeekResult> {
+  try {
+    let res = await fetch(url, {
+      headers: { Range: `bytes=0-${PEEK_BYTES}` },
+    });
+
+    if (res.status === 404) {
+      return { url, ok: false, version: null };
+    }
+
+    // Some CDNs ignore Range or reject it; fall back to a full GET.
+    if (!res.ok && res.status !== 206) {
+      res = await fetch(url);
+      if (res.status === 404) {
+        return { url, ok: false, version: null };
+      }
+      if (!res.ok) {
+        return { url, ok: false, version: null };
+      }
+    }
+
+    const raw = new Uint8Array(await res.arrayBuffer());
+    const buf = raw.byteLength > PEEK_BYTES + 1 ? raw.slice(0, PEEK_BYTES + 1) : raw;
+    return { url, ok: true, version: parseSpineVersionFromBytes(buf) };
+  } catch (err) {
+    console.warn(`[ba-story-player] Failed to peek spine skel: ${url}`, err);
+    return { url, ok: false, version: null };
+  }
+}
+
+function isSpine42Version(version: string | null): boolean {
+  return Boolean(version?.startsWith("4.2"));
+}
+
+/**
+ * Pick a reachable Spine 4.2 .skel for a named character sprite.
+ * Prefer ba-all-data-spine42 when both CDNs have 4.2.
+ */
+export async function resolveNamedSpineSkelUrl(skelUrl: string): Promise<string> {
+  const cacheKey = toBaAllDataCdnUrl(skelUrl);
+  const cached = resolveCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const task = (async () => {
+    const spine42Url = toSpine42CdnUrl(skelUrl);
+    const dataUrl = toBaAllDataCdnUrl(skelUrl);
+
+    const [spine42, data] = await Promise.all([
+      peekSpineSkel(spine42Url),
+      peekSpineSkel(dataUrl),
+    ]);
+
+    const candidates = [spine42, data];
+    const v42 = candidates.find(c => c.ok && isSpine42Version(c.version));
+    if (v42) {
+      if (v42.url !== skelUrl) {
+        console.info(
+          `[ba-story-player] Named spine resolved to 4.2:\n  ${skelUrl}\n  -> ${v42.url} (spine ${v42.version})`
+        );
+      }
+      return v42.url;
+    }
+
+    const available = candidates.filter(c => c.ok);
+    if (available.length > 0) {
+      const summary = available
+        .map(c => `${c.url} (spine ${c.version ?? "unknown"})`)
+        .join("\n  ");
+      throw new Error(
+        `Named spine has no Spine 4.2 copy (runtime only supports 4.2):\n  ${summary}`
+      );
+    }
+
+    throw new Error(`Named spine 404 on both CDNs:\n  ${spine42Url}\n  ${dataUrl}`);
+  })();
+
+  resolveCache.set(cacheKey, task);
+  try {
+    return await task;
+  } catch (err) {
+    resolveCache.delete(cacheKey);
+    throw err;
+  }
+}

--- a/lib/ba-story-player/lib/utils.ts
+++ b/lib/ba-story-player/lib/utils.ts
@@ -42,6 +42,9 @@ export function getOtherSoundUrls(): string[] {
  * @returns
  */
 function getSpine42Url(url: string) {
+  if (url.includes("ba-all-data-spine42")) {
+    return rewritePath(url);
+  }
   return rewritePath(url.replaceAll("ba-all-data", "ba-all-data-spine42"));
 }
 
@@ -111,9 +114,8 @@ export function getResourcesUrl(type: ResourcesTypes, arg: string): string {
       const skelPath = superSampling
         ? `${dataUrl}/spine/${filename}/${filename}${superSampling}/${filename}.skel`
         : `${dataUrl}/spine/${filename}/${filename}.skel`;
-      // ch*/np* sprites exist only on ba-all-data-spine42 (Spine 4.2).
-      // named sprites — on ba-all-data (Spine 4.2); spine42 has stale 3.8 copies
-      // FIXME: CI intervention needed
+      // ch*/np* generic sprites live on ba-all-data-spine42 (Spine 4.2).
+      // Named sprites may be on either CDN as 3.8 or 4.2 — resolved at load time.
       if (/^(ch|np)\d+/i.test(id ?? "")) {
         return getSpine42Url(skelPath);
       }


### PR DESCRIPTION
named characters' sprites can be in both `ba-all-data-spine42`/`ba-all-data`, or only in one route, or with unpredicted version (3.8/4.2). because of this chapters like 33080 cannot be loaded.

we can use workaround: for named sprites check both routes and sprite version before loading to player.